### PR TITLE
Add simplecov gem as the gems test coverage tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "rspec", "~> 3.0"
 end
+
+group :test do
+  gem "simplecov", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     byebug (11.1.1)
     diff-lcs (1.3)
+    docile (1.3.2)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -16,6 +17,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
 
 PLATFORMS
   ruby
@@ -23,6 +28,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   rspec (~> 3.0)
+  simplecov
 
 BUNDLED WITH
    2.1.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require "simplecov"
+SimpleCov.start
+
 require "tinadb"
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR aims to add a gem for test coverage. The gem is [simplecov](https://github.com/colszowka/simplecov).